### PR TITLE
Fix Reference field to accept an iterable

### DIFF
--- a/openerp/validators/validators.py
+++ b/openerp/validators/validators.py
@@ -179,6 +179,7 @@ class Selection(FancyValidator):
 
 class Reference(FancyValidator):
     if_empty = False
+    accept_iterator = True
 
     def _to_python(self, value, state):
 


### PR DESCRIPTION
Due the change in https://github.com/formencode/formencode/commit/df66b54722ea9fa49e76b37ec1db32a29b03d950
